### PR TITLE
Added price._adj_close to function _price_to_csvl

### DIFF
--- a/jsm/__init__.py
+++ b/jsm/__init__.py
@@ -142,6 +142,6 @@ class QuotesCsv(object):
         """株データをCSV形式に変換"""
         return [price.date.strftime('%Y-%m-%d'),
                 price.open, price.high, price.low, 
-                price.close, price.volume]
+                price.close, price.volume, price._adj_close]
 
 


### PR DESCRIPTION
Added adjusted close price (price._adj_close) so that the output historical CSV file includes adjusted close price (as its final column, next to price.volume), as yahoo japan database now apparently handles this correctly.