### PR TITLE
Add TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+python:
+  - 2.7
+  - 3.4
+
+install:
+  - python setup.py install
+  - pip install coveralls
+
+script:
+  - coverage run --source=jsm setup.py test
+
+after_success:
+  - coveralls


### PR DESCRIPTION
TravisCIの設定ファイルを追加しました.
Python 2.7, 3.4でsetup.py testが実行されますので
互換性の確認に使えると思います.
coveralls.ioでカバレッジの確認も可能です.
merge時の参考にご活用ください.